### PR TITLE
feat: plumb app_protocol for forwarded http_endpoint

### DIFF
--- a/__test__/connect.spec.mjs
+++ b/__test__/connect.spec.mjs
@@ -81,7 +81,7 @@ test("forward https", async (t) => {
 });
 
 test("forward http2", async (t) => {
-  const httpServer = await makeHttp(false, true);
+  const httpServer = await makeHttp({useHttp2: true});
   const listener = await ngrok.forward({
     // numeric port
     addr: parseInt(httpServer.listenTo.split(":")[1], 10),

--- a/examples/ngrok-forward-full.js
+++ b/examples/ngrok-forward-full.js
@@ -24,6 +24,7 @@ ngrok.consoleLog("INFO"); // turn on info logging
     // session configuration
     addr: `unix:${UNIX_SOCKET}`,
     // addr: `localhost:8080`,
+    // app_protocol: "http1",
     // authtoken: "<authtoken>",
     authtoken_from_env: true,
     on_status_change: (addr, error) => {

--- a/examples/ngrok-forward-full.js
+++ b/examples/ngrok-forward-full.js
@@ -24,7 +24,7 @@ ngrok.consoleLog("INFO"); // turn on info logging
     // session configuration
     addr: `unix:${UNIX_SOCKET}`,
     // addr: `localhost:8080`,
-    // app_protocol: "http1",
+    // app_protocol: "http2",
     // authtoken: "<authtoken>",
     authtoken_from_env: true,
     on_status_change: (addr, error) => {

--- a/examples/ngrok-http2.js
+++ b/examples/ngrok-http2.js
@@ -1,5 +1,5 @@
-const ngrok = require("../index.js");
 const http2 = require("node:http2");
+const ngrok = require("@ngrok/ngrok");
 
 const server = http2.createServer();
 server.on("error", (err) => console.error(err));

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface Config {
    */
   addr?: number|string
   /** The L7 application protocol to use for this edge, e.g. "http2" or "http1". */
-  appProtocol?: string
+  app_protocol?: string
   auth?: string|Array<string>
   /**
    * Configures the session to authenticate with the provided authtoken. You

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     #[napi(ts_type = "number|string")]
     pub addr: Option<String>,
     /// The L7 application protocol to use for this edge, e.g. "http2" or "http1".
+    #[napi(js_name = "app_protocol")]
     pub app_protocol: Option<String>,
     // Synonym for basic_auth
     #[napi(ts_type = "string|Array<string>")]

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -196,6 +196,7 @@ async fn http_endpoint(session: &Session, cfg: &Config) -> Result<String> {
     plumb_vec!(bld, cfg, scheme, schemes);
     plumb!(bld, cfg, domain, hostname); // synonym for domain
     plumb!(bld, cfg, domain);
+    plumb!(bld, cfg, app_protocol);
     plumb_vec!(bld, cfg, mutual_tlsca, mutual_tls_cas, vecu8);
     plumb_bool!(bld, cfg, compression);
     plumb_bool!(bld, cfg, websocket_tcp_conversion, websocket_tcp_converter);


### PR DESCRIPTION
Updates the forward to take an `app_protocol` attribute, but also, fixes config to accept `app_protocol` instead of `appProtocol`.
