### PR TITLE
Add ngrok specific readme to remix example

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,3 +1,17 @@
-To run:
-=======
+# To Run
+
 `node_modules/.bin/next`
+
+# Explanation
+
+The line `require("./ngrok.config.js");` is added to `next.config.js` which includes the code to setup the ngrok listener on the appropriate port, which defaults to `3000`.
+
+# Example Output
+
+```
+> node_modules/.bin/next
+ready - started server on 0.0.0.0:3000, url: http://localhost:3000
+warn  - Detected next.config.js, no exported configuration found. https://nextjs.org/docs/messages/empty-configuration
+event - compiled client and server successfully in 210 ms (154 modules)
+Forwarding to: localhost:3000 from ingress at: https://04d4d919d236.ngrok.app
+```

--- a/examples/remix/README.md
+++ b/examples/remix/README.md
@@ -1,8 +1,4 @@
-# Welcome to Remix!
-
-- [Remix Docs](https://remix.run/docs)
-
-## Development
+# This example wires up Remix development mode
 
 From your terminal:
 
@@ -12,42 +8,25 @@ npm run dev
 
 This starts your app in development mode, rebuilding assets on file changes.
 
-## Deployment
+# Explanation
 
-First, build your app for production:
+The line `require("./ngrok.config.js");` is added to `remix.config.js` which includes the code to setup the ngrok listener on the appropriate port, which defaults to `3000`.
 
-```sh
-npm run build
+# Example Output
+
+```
+> npm run dev
+
+> dev
+> remix dev
+
+Forwarding to: localhost:3000 from ingress at: https://935d84664d13.ngrok.app
+Remix App Server started at http://localhost:3000 (http://192.168.2.66:3000)
 ```
 
-Then run the app in production mode:
+# Additional information
 
-```sh
-npm start
-```
+For more information about Remix see:
 
-Now you'll need to pick a host to deploy it to.
-
-### DIY
-
-If you're familiar with deploying node applications, the built-in Remix app server is production-ready.
-
-Make sure to deploy the output of `remix build`
-
-- `build/`
-- `public/build/`
-
-### Using a Template
-
-When you ran `npx create-remix@latest` there were a few choices for hosting. You can run that again to create a new project, then copy over your `app/` folder to the new project that's pre-configured for your target server.
-
-```sh
-cd ..
-# create a new project, and pick a pre-configured host
-npx create-remix@latest
-cd my-new-remix-app
-# remove the new project's app (not the old one!)
-rm -rf app
-# copy your app over
-cp -R ../my-old-remix-app/app app
-```
+- [Remix Docs](https://remix.run/docs)
+- [Remix Readme](REMIX-README.md)

--- a/examples/remix/REMIX-README.md
+++ b/examples/remix/REMIX-README.md
@@ -1,0 +1,53 @@
+# Welcome to Remix!
+
+- [Remix Docs](https://remix.run/docs)
+
+## Development
+
+From your terminal:
+
+```sh
+npm run dev
+```
+
+This starts your app in development mode, rebuilding assets on file changes.
+
+## Deployment
+
+First, build your app for production:
+
+```sh
+npm run build
+```
+
+Then run the app in production mode:
+
+```sh
+npm start
+```
+
+Now you'll need to pick a host to deploy it to.
+
+### DIY
+
+If you're familiar with deploying node applications, the built-in Remix app server is production-ready.
+
+Make sure to deploy the output of `remix build`
+
+- `build/`
+- `public/build/`
+
+### Using a Template
+
+When you ran `npx create-remix@latest` there were a few choices for hosting. You can run that again to create a new project, then copy over your `app/` folder to the new project that's pre-configured for your target server.
+
+```sh
+cd ..
+# create a new project, and pick a pre-configured host
+npx create-remix@latest
+cd my-new-remix-app
+# remove the new project's app (not the old one!)
+rm -rf app
+# copy your app over
+cp -R ../my-old-remix-app/app app
+```


### PR DESCRIPTION
Moves remix's readme to `REMIX-README.md` and adds an ngrok specific one explaining what is wired up and how. Does similar readme update to nextjs.