### PR TITLE
feat: add appProtocol + label support

### DIFF
--- a/examples/ngrok-labeled.js
+++ b/examples/ngrok-labeled.js
@@ -26,6 +26,8 @@ builder.connect().then((session) => {
     .labeledListener()
     .label("edge", "edghts_<edge_id>")
     .metadata("example listener metadata from nodejs")
+    // Set the appProtocol for the listener, i.e. "http1" or "http2", default is "http1"
+    // .appProtocol("http2")
     .listen()
     .then((listener) => {
       console.log("Ingress established at: " + JSON.stringify(listener.labels()));

--- a/index.d.ts
+++ b/index.d.ts
@@ -704,6 +704,8 @@ export class LabeledListenerBuilder {
    * [Using Labels]: https://ngrok.com/docs/guides/using-labels-within-ngrok/
    */
   label(label: string, value: string): this
+  /** Set the L7 application portocol for this listener, i.e. "http1" or "http2" (defualts "http1") */
+  appProtocol(appProtocol: string): this
 }
 /**
  * The builder for an ngrok session.

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -282,6 +282,7 @@ async fn tls_endpoint(session: &Session, cfg: &Config) -> Result<String> {
 async fn labeled_listener(session: &Session, cfg: &Config) -> Result<String> {
     let mut bld = session.labeled_listener();
     plumb!(bld, cfg, metadata);
+    plumb!(bld, cfg, app_protocol);
     plumb_vec!(bld, cfg, label, labels, ":");
     Ok(bld.listen(None).await?.id())
 }

--- a/src/listener_builder.rs
+++ b/src/listener_builder.rs
@@ -188,6 +188,14 @@ macro_rules! make_listener_builder {
                 builder.label(label, value);
                 self
             }
+
+            /// Set the L7 application portocol for this listener, i.e. "http1" or "http2" (defaults "http1")
+            #[napi]
+            pub fn app_protocol(&mut self, app_protocol: String) -> &Self {
+                let mut builder = self.listener_builder.lock();
+                builder.app_protocol(app_protocol);
+                self
+            }
         }
     };
 }


### PR DESCRIPTION
Adds `appProtocol` support for labeled listeners using the builder or forward setup.