### PR TITLE
Update quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ pnpm add @ngrok/ngrok
       // Output ngrok url to console
       console.log(`Ingress established at: ${listener.url()}`);
     })();
+
+    process.stdin.resume();
     ```
 
 That's it! Your application should now be available through the url output in your terminal. 


### PR DESCRIPTION
The current example immediately kills the tunnel after starting it. Adding a line to resume the process so a tunnel is accessible at the ngrok URL.