### PR TITLE
add `traffic_policy`, remap `policy`->`traffic_policy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ mio = { version = "=0.8.6" }
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.1", default-features = false, features = ["napi4", "tokio_rt"] }
 napi-derive = "2.12.1"
-ngrok = { version = "=0.14.0-pre.13" }
+ngrok = { version = "=0.14.0-pre.14" }
 parking_lot = "0.12.1"
 regex = "1.9.5"
 rustls = "0.22.2"
@@ -32,3 +32,6 @@ napi-build = "2.0.1"
 
 [profile.release]
 lto = true
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["mio"]

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ const listener = await ngrok.forward({
   oidc_allow_domains: ["<domain>"],
   oidc_allow_emails: ["<email>"],
   oidc_scopes: ["<scope>"],
-  policy: "<policy_json>",
+  traffic_policy: "<policy_json>",
   request_header_remove: ["X-Req-Nope"],
   response_header_remove: ["X-Res-Nope"],
   request_header_add: ["X-Req-Yup:true"],

--- a/__test__/connect.spec.mjs
+++ b/__test__/connect.spec.mjs
@@ -338,3 +338,21 @@ test("policy", async (t) => {
   const response = await validateShutdown(t, httpServer, url);
   t.is("bar", response.headers["foo"]);
 });
+
+test("traffic policy", async (t) => {
+  const trafficPolicy = fs.readFileSync(path.resolve("__test__", "policy.json"), "utf8");
+
+  const httpServer = await makeHttp();
+  const listener = await ngrok.forward({
+    addr: httpServer.listenTo,
+    authtoken: process.env["NGROK_AUTHTOKEN"],
+    proto: "http",
+    trafficPolicy: trafficPolicy,
+  });
+  const url = listener.url();
+
+  t.truthy(url);
+  t.truthy(url.startsWith("https://"), url);
+  const response = await validateShutdown(t, httpServer, url);
+  t.is("bar", response.headers["foo"]);
+});

--- a/__test__/online.spec.mjs
+++ b/__test__/online.spec.mjs
@@ -544,3 +544,12 @@ test("policy", async (t) => {
   const response = await forwardValidateShutdown(t, httpServer, listener, listener.url());
   t.is("bar", response.headers["foo"]);
 });
+
+test("traffic policy", async (t) => {
+  const trafficPolicy = fs.readFileSync(path.resolve("__test__", "policy.json"), "utf8");
+
+  const [httpServer, session] = await makeHttpAndSession();
+  const listener = await session.httpEndpoint().trafficPolicy(trafficPolicy).listen();
+  const response = await forwardValidateShutdown(t, httpServer, listener, listener.url());
+  t.is("bar", response.headers["foo"]);
+});

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           "rust-src"
           "rustc"
           "rustfmt"
+          "rust-analyzer"
         ];
         node-toolchain = with pkgs; [
           nodejs

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,7 +221,7 @@ export interface Config {
   onLogEvent?: (data: string) => void
   /** 'closed' - connection is lost, 'connected' - reconnected */
   onStatusChange?: (status: string) => void
-  /** The Traffic Policy to use for this endpoint. */
+  /** DEPRECATED: use TrafficPolicy instead. */
   policy?: string
   /**
    * The port for the listener to forward to.
@@ -323,6 +323,8 @@ export interface Config {
   subdomain?: string
   /** Unused, will warn and be ignored */
   terminate_at?: string
+  /** The Traffic Policy to use for this endpoint. */
+  trafficPolicy?: string
   /** Whether to disable certificate verification for this listener */
   verify_upstream_tls?: boolean
   /**
@@ -349,7 +351,7 @@ export interface Config {
  *
  * See {@link forward} for the full set of options.
  */
-export function connect(config: Config|string|number): Promise<Listener>
+export declare function connect(config: Config|string|number): Promise<Listener>
 /**
  * Transform a json object configuration into a listener.
  * See {@link Config} for the full set of options.
@@ -359,25 +361,25 @@ export function connect(config: Config|string|number): Promise<Listener>
  * listener = await ngrok.forward({addr: "https://localhost:8443", authtoken_from_env: true});<br>
  * listener = await ngrok.forward({addr: "unix:///path/to/unix.socket", basic_auth: "ngrok:online1line", authtoken_from_env: true});
  */
-export function forward(config: Config|string|number): Promise<Listener>
+export declare function forward(config: Config|string|number): Promise<Listener>
 /** Close a listener with the given url, or all listeners if no url is defined. */
-export function disconnect(url?: string | undefined | null): Promise<void>
+export declare function disconnect(url?: string | undefined | null): Promise<void>
 /** Close all listeners. */
-export function kill(): Promise<void>
+export declare function kill(): Promise<void>
 /** Retrieve a list of non-closed listeners, in no particular order. */
-export function listeners(): Promise<Array<Listener>>
+export declare function listeners(): Promise<Array<Listener>>
 /** Retrieve listener using the id */
-export function getListener(id: string): Promise<Listener | null>
+export declare function getListener(id: string): Promise<Listener | null>
 /** Retrieve listener using the url */
-export function getListenerByUrl(url: string): Promise<Listener | null>
+export declare function getListenerByUrl(url: string): Promise<Listener | null>
 /**
  * Register a callback function that will receive logging event information.
  * An absent callback will unregister an existing callback function.
  * The log level defaults to INFO, it can be set to one of ERROR, WARN, INFO, DEBUG, or TRACE.
  */
-export function loggingCallback(callback?: (level: string, target: string, message: string) => void, level?: string): void
+export declare function loggingCallback(callback?: (level: string, target: string, message: string) => void, level?: string): void
 /** Set the default auth token to use for any future sessions. */
-export function authtoken(authtoken: string): Promise<void>
+export declare function authtoken(authtoken: string): Promise<void>
 /**
  * An ngrok listener.
  *
@@ -587,6 +589,7 @@ export class HttpListenerBuilder {
    */
   forwardsTo(forwardsTo: string): this
   policy(policy: string): this
+  trafficPolicy(trafficPolicy: string): this
 }
 /**
  *r" An ngrok listener backing a TCP endpoint.
@@ -638,6 +641,7 @@ export class TcpListenerBuilder {
    */
   forwardsTo(forwardsTo: string): this
   policy(policy: string): this
+  trafficPolicy(trafficPolicy: string): this
   /**
    * The TCP address to request for this edge.
    * These addresses can be reserved in the [ngrok dashboard] to use across sessions. For example: remote_addr("2.tcp.ngrok.io:21746")
@@ -696,6 +700,7 @@ export class TlsListenerBuilder {
    */
   forwardsTo(forwardsTo: string): this
   policy(policy: string): this
+  trafficPolicy(trafficPolicy: string): this
   /**
    * The domain to request for this edge, any valid domain or hostname that you have
    * previously registered with ngrok. If using a custom domain, this requires
@@ -940,18 +945,3 @@ export class UpdateRequest {
   /** Whether or not updating to the same major version is sufficient. */
   permitMajorVersion: boolean
 }
-/**
- * Get a listenable ngrok listener, suitable for passing to net.Server.listen().
- * Uses the NGROK_AUTHTOKEN environment variable to authenticate.
- */
-export function listenable(): Listener;
-/**
- * Start the given net.Server listening to a generated, or passed in, listener.
- * Uses the NGROK_AUTHTOKEN environment variable to authenticate if a new listener is created.
- */
-export function listen(server: import("net").Server, listener?: Listener): Listener;
-/**
- * Register a console.log callback for ngrok INFO logging.
- * Optionally set the logging level to one of ERROR, WARN, INFO, DEBUG, or TRACE.
- */
-export function consoleLog(level?: String): void;

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,7 @@ pub struct Config {
     /// 'closed' - connection is lost, 'connected' - reconnected
     #[napi(ts_type = "(status: string) => void")]
     pub on_status_change: Option<bool>,
-    /// The Traffic Policy to use for this endpoint.
+    /// DEPRECATED: use TrafficPolicy instead.
     pub policy: Option<String>,
     /// The port for the listener to forward to.
     /// Only used if addr is not defined.
@@ -301,6 +301,8 @@ pub struct Config {
     /// Unused, will warn and be ignored
     #[napi(js_name = "terminate_at")]
     pub terminate_at: Option<String>,
+    /// The Traffic Policy to use for this endpoint.
+    pub traffic_policy: Option<String>,
     /// Whether to disable certificate verification for this listener
     #[napi(js_name = "verify_upstream_tls")]
     pub verify_upstream_tls: Option<bool>,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -102,11 +102,9 @@ macro_rules! config_common {
         plumb!($builder, $config, proxy_proto);
         plumb!($builder, $config, forwards_to);
         plumb!($builder, $config, verify_upstream_tls);
-
-        // returns a Result, so we can't use the macro
-        if let Some(ref v) = $config.policy {
-            $builder.policy(v.clone())?;
-        }
+        plumb!($builder, $config, traffic_policy);
+        // policy is in the process of being deprecated. for now, we just remap it to traffic_policy
+        plumb!($builder, $config, traffic_policy, policy);
     };
 }
 

--- a/src/listener_builder.rs
+++ b/src/listener_builder.rs
@@ -165,12 +165,16 @@ macro_rules! make_listener_builder {
                 self
             }
             #[napi]
-            pub fn policy(&mut self, policy: String) -> Result<&Self> {
+            pub fn policy(&mut self, policy: String) -> &Self {
                 let mut builder = self.listener_builder.lock();
-                match builder.policy(policy.as_str()) {
-                    Ok(_) => Ok(self),
-                    Err(e) => Err(napi_err(format!("Error parsing policy, {e}"))),
-                }
+                builder.traffic_policy(policy);
+                self
+            }
+            #[napi]
+            pub fn traffic_policy(&mut self, traffic_policy: String) -> &Self {
+                let mut builder = self.listener_builder.lock();
+                builder.traffic_policy(traffic_policy);
+                self
             }
         }
     };


### PR DESCRIPTION
### Why 
Currently, we are in the process of erasing strict policy types from our SDKs. This changes makes sure policy is sent to the backend as a traffic_policy string as opposed to a strictly formatted policy struct.

### How
The traffic policy field already exists and functions in the underlying rust SDK. So all we have to do is plumb the new field through to Rust. Additionally, instances of Policy are remapped to traffic policy.

### Validation
Current unit tests continue to run.
An additional unit test was added using the new TrafficPolicy field.

### Additional Changes

#### Rust LSP
To make development easier, I added the rust SDK to our nix flake.

#### Adding `mio` to the `udeps` ignore list
`cargo udeps` keeps claiming that it is unused. However, if I remove it, everything implodes.
I keep seeing stuff about `udeps` having false positives so i just decided to ignore it. We have done a similar thing in the Python API.