### PR TITLE
1.4.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,6 +21,7 @@ Release
 1. `git push origin <username>/<version>`
     - Or with graphite: `gt track` and `gt submit`
 1. Create a pull request off this branch
-    - Make sure the name of the pull request is also just the `<version>` so the workflow will know to do a release
+    - Make sure the name of the pull request is also just the `<version>` so the workflow will know to do a release.
+    - Do not prepend the `<version>` with `v`. For instance, if releasing `1.1.0`, the PR should be named `1.1.0`, NOT `v1.1.0`
 1. Merge the pull request
 1. Verify release appears on [NPM](https://www.npmjs.com/package/@ngrok/ngrok?activeTab=versions)


### PR DESCRIPTION
I missed the note about needing to name the branch properly in order to trigger a release.