### PR TITLE
make traffic_policy fit normal format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Fix `traffic_policy` naming for `ngrok.forward`
+
 ## 1.4.0
 
 - Rename `policy` to `traffic_policy`

--- a/__test__/connect.spec.mjs
+++ b/__test__/connect.spec.mjs
@@ -347,7 +347,7 @@ test("traffic policy", async (t) => {
     addr: httpServer.listenTo,
     authtoken: process.env["NGROK_AUTHTOKEN"],
     proto: "http",
-    trafficPolicy: trafficPolicy,
+    traffic_policy: trafficPolicy,
   });
   const url = listener.url();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -324,7 +324,7 @@ export interface Config {
   /** Unused, will warn and be ignored */
   terminate_at?: string
   /** The Traffic Policy to use for this endpoint. */
-  trafficPolicy?: string
+  traffic_policy?: string
   /** Whether to disable certificate verification for this listener */
   verify_upstream_tls?: boolean
   /**
@@ -945,18 +945,3 @@ export class UpdateRequest {
   /** Whether or not updating to the same major version is sufficient. */
   permitMajorVersion: boolean
 }
-/**
- * Get a listenable ngrok listener, suitable for passing to net.Server.listen().
- * Uses the NGROK_AUTHTOKEN environment variable to authenticate.
- */
-export function listenable(): Listener;
-/**
- * Start the given net.Server listening to a generated, or passed in, listener.
- * Uses the NGROK_AUTHTOKEN environment variable to authenticate if a new listener is created.
- */
-export function listen(server: import("net").Server, listener?: Listener): Listener;
-/**
- * Register a console.log callback for ngrok INFO logging.
- * Optionally set the logging level to one of ERROR, WARN, INFO, DEBUG, or TRACE.
- */
-export function consoleLog(level?: String): void;

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,6 +302,7 @@ pub struct Config {
     #[napi(js_name = "terminate_at")]
     pub terminate_at: Option<String>,
     /// The Traffic Policy to use for this endpoint.
+    #[napi(js_name = "traffic_policy")]
     pub traffic_policy: Option<String>,
     /// Whether to disable certificate verification for this listener
     #[napi(js_name = "verify_upstream_tls")]


### PR DESCRIPTION
I made a mistake and didn't add a proper `napi` tag to the `traffic_policy` variable. 

This changes the name to match the casing of the other configuration options.