### PR TITLE
fix: close ngrok session in disconnect function

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -371,9 +371,11 @@ fn warn_unused(config: &Config) {
 pub async fn disconnect(url: Option<String>) -> Result<()> {
     listener::close_url(url.clone()).await?;
 
-    // if closing every listener, remove any stored session
+    // if closing every listener, close and remove the stored session
     if url.as_ref().is_none() {
-        SESSION.lock().await.take();
+        if let Some(session) = SESSION.lock().await.take() {
+            session.close().await?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
The disconnect function was only removing the session from the mutex without properly closing it when calling `ngrok.kill` or `ngrok.disconnect`. This change ensures the session's close() method is called before removing it, which properly shuts down the ngrok session/agent.

Starting a tunnel and running `await ngrok.kill()`:
![image](https://github.com/user-attachments/assets/96845386-a6a5-4a94-b56e-0c4d7aa8f5ed)

Then running `ngrok http 80` in another terminal:
![image](https://github.com/user-attachments/assets/4c251ebf-62ad-4d47-97ef-bb1995ae21e9)

Attempting to run the script while the CLI agent is running (as a test that I do indeed get this when >1 agent runs):
![image](https://github.com/user-attachments/assets/07cb3653-2b70-41ea-91c7-cfdc1762309f)

**Note:** While this does fix #148 the session still can take up to 1-3 seconds to close. Mileage may vary.

fixes #148

---

**Note:** The smoke test pass, I could not run the full suite so need to test this on my other machine. Additionally, it was not clear whether I should commit the index file generated by the build process or let the workflow do this. On my machine I could only run the debug build process so I did not commit those files.