### PR TITLE
README.md: remove pooling_enabled option from ngrok configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ const listener = await ngrok.forward({
   oidc_allow_domains: ["<domain>"],
   oidc_allow_emails: ["<email>"],
   oidc_scopes: ["<scope>"],
-  pooling_enabled: false,
   traffic_policy: "<policy_json>",
   request_header_remove: ["X-Req-Nope"],
   response_header_remove: ["X-Res-Nope"],


### PR DESCRIPTION
Hello,I found README.md fix point.

This pull request includes a small change to the `README.md` file. The change removes the `pooling_enabled` configuration option from the example configuration.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L263): Removed the `pooling_enabled` option from the example configuration.
*  I can see from [src/config.rs](https://github.com/ngrok/ngrok-javascript/blob/main/src/config.rs), there was no `pooling_enabled` option