### PR TITLE
Allow manually dispatching workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - '**/*.gitignore'
       - .editorconfig
       - docs/**
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened] # when a pull request is opened or reopened
     branches:


### PR DESCRIPTION
Right now, we've got a bit of a catch-22: we only run the publish action when you push a branch with a commit message in the format `\d+\.\d+\.\d+` to `main`...which we literally prevent you doing. Instead, allow manually triggering it.